### PR TITLE
Exclude repository-config from exported archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.git*      	export-ignore
+.travis.yml	export-ignore


### PR DESCRIPTION
when using 'git archive' to export a repository into an archive (e.g. as
is done by github/gitlab to create release-tarballs), we don't really want
to export any repository configuration (e.g. .gitignore), as this
interacts badly with downstream importing the release-tarball into their own
repositories.

e.g. Debian (for the Debian packages) uses their own git-repository for the
packaging. having debian/ ignored there is rather pointless.