### PR TITLE
Debian patches

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.git*      	export-ignore
+.travis.yml	export-ignore

--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from optparse import OptionParser
 from os.path import abspath, dirname, join

--- a/install/build-desktop-file
+++ b/install/build-desktop-file
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from optparse import OptionParser
 from os import makedirs, sep

--- a/install/build-source-package
+++ b/install/build-source-package
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from optparse import OptionParser
 from os import makedirs, pardir

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -24,6 +24,9 @@
 #include "engine.h"
 #include "error.h"
 
+// RtError was renamed to RtMidiError in rtmidi 2.1
+typedef RtMidiError RtError;
+
 #if QT_VERSION >= 0x040700
 #include <QtCore/QDateTime>
 #else
@@ -62,9 +65,6 @@ Engine::Engine(QObject *parent):
             break;
         case RtMidi::UNIX_JACK:
             driverNames.append(tr("JACK Audio Connection Kit"));
-            break;
-        case RtMidi::WINDOWS_KS:
-            driverNames.append(tr("Windows Kernel Streaming"));
             break;
         case RtMidi::WINDOWS_MM:
             driverNames.append(tr("Windows Multimedia MIDI"));

--- a/src/engine.h
+++ b/src/engine.h
@@ -21,6 +21,7 @@
 #define __ENGINE_H__
 
 #include <QtCore/QByteArray>
+#include <QtCore/QObject>
 #include <QtCore/QStringList>
 #include <QtCore/QVector>
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -63,7 +63,7 @@ isEmpty(DATADIR) {
     MIDISNOOP_DATA_INSTALL_PATH = $${DATADIR}
 }
 
-CONFIG += console warn_on
+CONFIG += console link_pkgconfig warn_on
 DEFINES += MIDISNOOP_MAJOR_VERSION=$${MAJOR_VERSION} \
     MIDISNOOP_MINOR_VERSION=$${MINOR_VERSION} \
     MIDISNOOP_REVISION=$${REVISION}
@@ -83,7 +83,7 @@ HEADERS += aboutview.h \
     messageview.h \
     util.h \
     view.h
-LIBS += -lrtmidi
+PKGCONFIG += rtmidi
 MOC_DIR = $${MAKEDIR}
 OBJECTS_DIR = $${MAKEDIR}
 QT += core gui uitools widgets

--- a/templates/midisnoop.desktop
+++ b/templates/midisnoop.desktop
@@ -1,12 +1,12 @@
 [Desktop Entry]
 Categories=Audio;AudioVideo;Qt;
 Comment=MIDI monitor and prober.
-Encoding=UTF-8
+Keywords=midi;monitor;jackd;alsa;
 Exec=${binDir}/midisnoop
 GenericName=Midisnoop
 GenericName[en_US]=Midisnoop
 Hidden=false
-#Icon=${dataDir}/icons/midisnoop.png
+Icon=midisnoop
 Name=Midisnoop
 Terminal=false
 Type=Application


### PR DESCRIPTION
these are patches taken from the Debian packaging of midisnoop.

- don't export gitignore (taken from #8)
- add "Icon" & "Keywords" from midisnoop.deskop
- exclude obsolete "Encoding" from midisnoop.deskop
- fix builds with RtMidi-2.1
- use `pkg-config` for RtMidi (rather than assuming some simplistic linker/compiler flags).
  This fixes the FTBFS with new versions of RtMidi where the include directory has moved and a `-I` flag is now needed.
- add include to fix compilation with Qt5
- switch configure & install-scripts to python3 (Python2 is dead!)